### PR TITLE
Handle fallback when no channel or version set

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -ex
+
 echo "Installing .NET core"
 echo "--------------------"
 echo ""
@@ -25,6 +28,9 @@ elif [ -n "${version}" ]
   then
     echo "Installing version: ${version}"
     ./dotnet-install.sh  --version "${version}"
+else
+    echo "Installing default channel and version"
+    ./dotnet-install.sh
 fi
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
Fixes #2 by just executing `dotnet-install.sh` when no channel or version is set.